### PR TITLE
Inherit from Print instead of overloading print...(), fix crash

### DIFF
--- a/examples/demo/demo.ino
+++ b/examples/demo/demo.ino
@@ -51,4 +51,10 @@ void setup() {
 }
 
 void loop() {
+    delay(2000);
+
+    WebSerial.print(F("IP address: "));
+    WebSerial.println(WiFi.localIP());
+    WebSerial.printf("Millis=%lu\n", millis());
+    WebSerial.printf("Free heap=[%lu]\n", ESP.getFreeHeap());
 }

--- a/examples/demo/demo.ino
+++ b/examples/demo/demo.ino
@@ -56,5 +56,5 @@ void loop() {
     WebSerial.print(F("IP address: "));
     WebSerial.println(WiFi.localIP());
     WebSerial.printf("Millis=%lu\n", millis());
-    WebSerial.printf("Free heap=[%lu]\n", ESP.getFreeHeap());
+    WebSerial.printf("Free heap=[%u]\n", ESP.getFreeHeap());
 }

--- a/examples/demo_ap/demo_ap.ino
+++ b/examples/demo_ap/demo_ap.ino
@@ -48,4 +48,10 @@ void setup() {
 }
 
 void loop() {
+    delay(2000);
+
+    WebSerial.print(F("IP address: "));
+    WebSerial.println(WiFi.localIP());
+    WebSerial.printf("Millis=%lu\n", millis());
+    WebSerial.printf("Free heap=[%lu]\n", ESP.getFreeHeap());
 }

--- a/examples/demo_ap/demo_ap.ino
+++ b/examples/demo_ap/demo_ap.ino
@@ -53,5 +53,5 @@ void loop() {
     WebSerial.print(F("IP address: "));
     WebSerial.println(WiFi.localIP());
     WebSerial.printf("Millis=%lu\n", millis());
-    WebSerial.printf("Free heap=[%lu]\n", ESP.getFreeHeap());
+    WebSerial.printf("Free heap=[%u]\n", ESP.getFreeHeap());
 }

--- a/src/WebSerial.cpp
+++ b/src/WebSerial.cpp
@@ -66,26 +66,15 @@ void WebSerialClass::onError(ErrHandler callbackFunc) {
 }
 
 // Print
-void WebSerialClass::print(String m) { _ws->textAll(m); }
-void WebSerialClass::print(const char *m) { _ws->textAll(m); }
-void WebSerialClass::print(char *m) { _ws->textAll(m); }
-void WebSerialClass::print(int m) { _ws->textAll(String(m)); }
-void WebSerialClass::print(uint8_t m) { _ws->textAll(String(m)); }
-void WebSerialClass::print(uint16_t m) { _ws->textAll(String(m)); }
-void WebSerialClass::print(uint32_t m) { _ws->textAll(String(m)); }
-void WebSerialClass::print(double m) { _ws->textAll(String(m)); }
-void WebSerialClass::print(float m) { _ws->textAll(String(m)); }
+size_t WebSerialClass::write(uint8_t m) {
+  _ws->textAll((const char *)&(m), 1);
+  return(1);
+}
 
-// Print with New Line
-void WebSerialClass::println(String m) { _ws->textAll(m + "\n"); }
-void WebSerialClass::println(const char *m) { _ws->textAll(String(m) + "\n"); }
-void WebSerialClass::println(char *m) { _ws->textAll(String(m) + "\n"); }
-void WebSerialClass::println(int m) { _ws->textAll(String(m) + "\n"); }
-void WebSerialClass::println(uint8_t m) { _ws->textAll(String(m) + "\n"); }
-void WebSerialClass::println(uint16_t m) { _ws->textAll(String(m) + "\n"); }
-void WebSerialClass::println(uint32_t m) { _ws->textAll(String(m) + "\n"); }
-void WebSerialClass::println(float m) { _ws->textAll(String(m) + "\n"); }
-void WebSerialClass::println(double m) { _ws->textAll(String(m) + "\n"); }
+size_t WebSerialClass::write(const uint8_t* buffer, size_t size) {
+  _ws->textAll((const char *)buffer, size);
+  return(size);
+}
 
 #if defined(WEBSERIAL_DEBUG)
 void WebSerialClass::DEBUG_WEB_SERIAL(const char *message) {

--- a/src/WebSerial.cpp
+++ b/src/WebSerial.cpp
@@ -67,12 +67,16 @@ void WebSerialClass::onError(ErrHandler callbackFunc) {
 
 // Print
 size_t WebSerialClass::write(uint8_t m) {
-  _ws->textAll((const char *)&(m), 1);
+  if (_ws != NULL) {
+    _ws->textAll((const char *)&(m), 1);
+  }
   return(1);
 }
 
 size_t WebSerialClass::write(const uint8_t* buffer, size_t size) {
-  _ws->textAll((const char *)buffer, size);
+  if (_ws != NULL) {
+    _ws->textAll((const char *)buffer, size);
+  }
   return(size);
 }
 

--- a/src/WebSerialLite.h
+++ b/src/WebSerialLite.h
@@ -43,43 +43,8 @@ class WebSerialClass {
 
   // Print
 
-  void print(String m = "");
-
-  void print(const char *m);
-
-  void print(char *m);
-
-  void print(int m);
-
-  void print(uint8_t m);
-
-  void print(uint16_t m);
-
-  void print(uint32_t m);
-
-  void print(double m);
-
-  void print(float m);
-
-  // Print with New Line
-
-  void println(String m = "");
-
-  void println(const char *m);
-
-  void println(char *m);
-
-  void println(int m);
-
-  void println(uint8_t m);
-
-  void println(uint16_t m);
-
-  void println(uint32_t m);
-
-  void println(float m);
-
-  void println(double m);
+  size_t write(uint8_t);
+  size_t write(const uint8_t* buffer, size_t size);
 
  private:
   AsyncWebServer *_server;

--- a/src/WebSerialLite.h
+++ b/src/WebSerialLite.h
@@ -41,7 +41,7 @@ class WebSerialClass : public Print {
   void onMessage(RecvMsgHandlerPlus callbackFunc);
   void onError(ErrHandler callbackFunc);
 
-   // Print
+  // Print
 
   size_t write(uint8_t);
   size_t write(const uint8_t* buffer, size_t size);

--- a/src/WebSerialLite.h
+++ b/src/WebSerialLite.h
@@ -41,45 +41,10 @@ class WebSerialClass : public Print {
   void onMessage(RecvMsgHandlerPlus callbackFunc);
   void onError(ErrHandler callbackFunc);
 
-  // Print
+   // Print
 
-  void print(String m = "");
-
-  void print(const char *m);
-
-  void print(char *m);
-
-  void print(int m);
-
-  void print(uint8_t m);
-
-  void print(uint16_t m);
-
-  void print(uint32_t m);
-
-  void print(double m);
-
-  void print(float m);
-
-  // Print with New Line
-
-  void println(String m = "");
-
-  void println(const char *m);
-
-  void println(char *m);
-
-  void println(int m);
-
-  void println(uint8_t m);
-
-  void println(uint16_t m);
-
-  void println(uint32_t m);
-
-  void println(float m);
-
-  void println(double m);
+  size_t write(uint8_t);
+  size_t write(const uint8_t* buffer, size_t size);
 
  private:
   AsyncWebServer *_server;

--- a/src/WebSerialLite.h
+++ b/src/WebSerialLite.h
@@ -31,7 +31,7 @@ typedef std::function<void(AsyncWebSocketClient *, uint16_t code,
 // Uncomment to enable webserial debug mode
 // #define WEBSERIAL_DEBUG
 
-class WebSerialClass {
+class WebSerialClass : public Print {
  public:
   void begin(AsyncWebServer *server, const char *url = "/webserial");
 
@@ -43,8 +43,43 @@ class WebSerialClass {
 
   // Print
 
-  size_t write(uint8_t);
-  size_t write(const uint8_t* buffer, size_t size);
+  void print(String m = "");
+
+  void print(const char *m);
+
+  void print(char *m);
+
+  void print(int m);
+
+  void print(uint8_t m);
+
+  void print(uint16_t m);
+
+  void print(uint32_t m);
+
+  void print(double m);
+
+  void print(float m);
+
+  // Print with New Line
+
+  void println(String m = "");
+
+  void println(const char *m);
+
+  void println(char *m);
+
+  void println(int m);
+
+  void println(uint8_t m);
+
+  void println(uint16_t m);
+
+  void println(uint32_t m);
+
+  void println(float m);
+
+  void println(double m);
 
  private:
   AsyncWebServer *_server;


### PR DESCRIPTION
~~Stolen from~~ Inspired by https://github.com/ayushsharma82/WebSerial/pull/57 .

Much more generic way of defining the class, which allows for things like `printf` or inserting items like `Wifi.localIP()` .

Also, since I replaced all my print statements with this, it would crash when the server wasn't ready. That has been fixed with a quick NULL check.