### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-           repository: adafruit/ci-arduino
+           repository: ayushsharma82/ci-arduino
            path: ci
 
       - name: pre-install


### PR DESCRIPTION
Ci build is currently failing because of this issue: https://github.com/adafruit/ci-arduino/issues/169

The problem is that even if your code is compatible, dependencies might not be.

ideally, you would want to fork yourself the ci-arduino repo and do the same changes as ayushsharma82/ci-arduino in order to point to your own fork.